### PR TITLE
Adding defaults to booleans in kondo model

### DIFF
--- a/db/migrate/20201124111634_add_defaults_to_kondo_model.rb
+++ b/db/migrate/20201124111634_add_defaults_to_kondo_model.rb
@@ -1,0 +1,6 @@
+class AddDefaultsToKondoModel < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :kondos, :reserved, false
+    change_column_default :kondos, :active, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_23_170716) do
+ActiveRecord::Schema.define(version: 2020_11_24_111634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,8 +29,8 @@ ActiveRecord::Schema.define(version: 2020_11_23_170716) do
     t.text "description"
     t.string "location"
     t.string "picture"
-    t.boolean "reserved"
-    t.boolean "active"
+    t.boolean "reserved", default: false
+    t.boolean "active", default: true
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
added a migration to update the default values for "active"(true) and "reserved"(false) in the Kondo model 